### PR TITLE
Type: fix

### DIFF
--- a/pc-hub/app/views/applications/_mobile_form.html.erb
+++ b/pc-hub/app/views/applications/_mobile_form.html.erb
@@ -8,11 +8,11 @@
     <% end %>
     <div class="row">
       <div class="col-md-6">
-      <%= f.text_field :app_link, label: "App link", help: "If the app is not on Play Store or Apple Store yet, keep it blank" %>
+      <%= f.url_field :app_link, label: "App link", help: "If the app is not on Play Store or Apple Store yet, keep it blank" %>
       <%= f.file_field :app_image, help: "Image to illustrate the application page" %>
       </div>
       <div class="col-md-6">
-        <%= f.text_field :repository_link, help: "Github link" %>
+        <%= f.url_field :repository_link, help: "Github link" %>
         <%= f.file_field :slider_image, help: "Image to be shown on the homepage slider" %>
       </div>
     </div>   

--- a/pc-hub/app/views/applications/_web_form.html.erb
+++ b/pc-hub/app/views/applications/_web_form.html.erb
@@ -5,11 +5,11 @@
     <%= f.text_field :short_description, label: "Short Description", help: "Short description to be shown on the homepage slider" %>
     <div class="row">
 	    <div class="col-md-6">
-	    <%= f.text_field :app_link, label: "Website link", help: "Keep it blank if the application doesn't have a website yet" %>
+	    <%= f.url_field :app_link, label: "Website link", help: "Keep it blank if the application doesn't have a website yet" %>
 	    <%= f.file_field :app_image, help: "Image to illustrate the application page" %>
 	    </div>
 	    <div class="col-md-6">
-		    <%= f.text_field :repository_link, help: "Github link" %>
+		    <%= f.url_field :repository_link, help: "Github link" %>
 		    <%= f.file_field :slider_image, help: "Image to be shown on the homepage slider" %>
 	    </div>
     </div>   


### PR DESCRIPTION

### Description
Add HTML5 field validation for url fields on the web and mobile application forms, if you don't enter a URL in the correct format then the links do not work when you view a mobile or web application.

Fixes #40 (https://github.com/systers/pchub/issues/40)

### Type of Change:
- Code


**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I manually tested via the UI to verify that when creating an application, I am prompted with a warning if I do not enter a valid url.

![screen shot 2018-05-16 at 6 06 43 am](https://user-images.githubusercontent.com/4753589/40118749-a04168bc-58cf-11e8-8963-30f85b140148.png)

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 

currently the tests are failing - and were failing before these changes were made.
