### PR TITLE
Corrected the typo "Forgout" --> "Forgot"

### DIFF
--- a/pc-hub/app/views/users/sessions/new.html.erb
+++ b/pc-hub/app/views/users/sessions/new.html.erb
@@ -16,7 +16,7 @@
                        <%= f.submit "Log in", class: "btn btn-success" %>
                     </div>
                     <br>
-                    <%= link_to "Forgout your password?", new_password_path(resource_name), 
+                    <%= link_to "Forgot your password?", new_password_path(resource_name), 
                       class: "brand-blue" %>
                     <br><br>
                     <%= link_to "New here? Create an account", new_user_registration_path,


### PR DESCRIPTION
### Description
Corrected the typo "Forgout" --> "Forgot" on the login screen.

Fixes #58  [https://github.com/systers/pchub/issues/58]

### Type of Change:
**Delete irrelevant options.**

- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Verified the correct spelling appears on the login page.


### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
